### PR TITLE
Add hyphenated tag support

### DIFF
--- a/obsidian-agent/agent/frontmatter_handler.py
+++ b/obsidian-agent/agent/frontmatter_handler.py
@@ -67,7 +67,8 @@ def normalize_tags(post: frontmatter.Post) -> bool:
     modified = False
     
     # Extract tags from content (hashtags)
-    content_tags = re.findall(r'#(\w+)', post.content)
+    # Support hyphenated tags like #time-management
+    content_tags = re.findall(r'#([\w-]+)', post.content)
     
     # Get existing frontmatter tags
     fm_tags = post.metadata.get('tags', [])

--- a/obsidian-agent/tests/test_tidier.py
+++ b/obsidian-agent/tests/test_tidier.py
@@ -74,11 +74,21 @@ class TestTidier:
         """Test that existing frontmatter tags are merged with content tags."""
         post = frontmatter.Post("Content with #newTag here.")
         post.metadata = {'tags': ['existingTag']}
-        
+
         result = normalize_tags(post)
-        
+
         assert result is True
         assert set(post.metadata['tags']) == {'existingTag', 'newTag'}
+
+    def test_normalize_tags_hyphenated(self):
+        """Tags with hyphens should be detected and normalized."""
+        post = frontmatter.Post("Working on better #time-management skills.")
+        post.metadata = {'tags': []}
+
+        result = normalize_tags(post)
+
+        assert result is True
+        assert post.metadata['tags'] == ['time-management']
     
     def test_normalize_tags_no_changes(self):
         """Test that no changes are made when tags are already normalized."""


### PR DESCRIPTION
## Summary
- support hyphenated tags when normalizing frontmatter
- test tag normalization with a hyphenated tag

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'openai')*

------
https://chatgpt.com/codex/tasks/task_e_6846d8870f2c8326bb7b2c7b162093da