### PR TITLE
Support hyphenated hashtags

### DIFF
--- a/obsidian-agent/agent/frontmatter_handler.py
+++ b/obsidian-agent/agent/frontmatter_handler.py
@@ -67,7 +67,7 @@ def normalize_tags(post: frontmatter.Post) -> bool:
     modified = False
     
     # Extract tags from content (hashtags)
-    content_tags = re.findall(r'#(\w+)', post.content)
+    content_tags = re.findall(r'#([\w-]+)', post.content)
     
     # Get existing frontmatter tags
     fm_tags = post.metadata.get('tags', [])

--- a/obsidian-agent/tests/test_tidier.py
+++ b/obsidian-agent/tests/test_tidier.py
@@ -64,11 +64,21 @@ class TestTidier:
         """Test that hashtags in content are extracted to frontmatter."""
         post = frontmatter.Post("This is content with #productivity and #learning tags.")
         post.metadata = {'tags': []}
-        
+
         result = normalize_tags(post)
-        
+
         assert result is True
         assert set(post.metadata['tags']) == {'productivity', 'learning'}
+
+    def test_normalize_tags_hyphenated(self):
+        """Tags with hyphens are correctly extracted."""
+        post = frontmatter.Post("Content with #my-tag and #another-tag.")
+        post.metadata = {'tags': []}
+
+        result = normalize_tags(post)
+
+        assert result is True
+        assert set(post.metadata['tags']) == {'my-tag', 'another-tag'}
     
     def test_normalize_tags_merge_existing(self):
         """Test that existing frontmatter tags are merged with content tags."""


### PR DESCRIPTION
## Summary
- extend tag normalization to capture words with hyphens
- ensure hyphenated tags handled in tests

## Testing
- `pytest -q obsidian-agent/tests/test_tidier.py` *(fails: ModuleNotFoundError: No module named 'frontmatter')*

------
https://chatgpt.com/codex/tasks/task_e_6846d885432483269eb733122b933c10